### PR TITLE
flow_ebos: tell the ebos in ourselves to not handle SWATINIT

### DIFF
--- a/opm/autodiff/BlackoilModelEbos.hpp
+++ b/opm/autodiff/BlackoilModelEbos.hpp
@@ -82,6 +82,10 @@ namespace Properties {
 NEW_TYPE_TAG(EclFlowProblem, INHERITS_FROM(BlackOilModel, EclBaseProblem));
 SET_BOOL_PROP(EclFlowProblem, DisableWells, true);
 SET_BOOL_PROP(EclFlowProblem, EnableDebuggingChecks, false);
+
+// SWATINIT is done by the flow part of flow_ebos. this can be removed once the legacy
+// code for fluid and satfunc handling gets fully retired.
+SET_BOOL_PROP(EclFlowProblem, EnableSwatinit, false);
 }}
 
 namespace Opm {


### PR DESCRIPTION
because the flow part also wants to do this. (and it is quite a bit
more stubborn!)